### PR TITLE
remove foreign_key flag from migration

### DIFF
--- a/db/migrate/20150323225455_create_memories.rb
+++ b/db/migrate/20150323225455_create_memories.rb
@@ -4,7 +4,7 @@ class CreateMemories < ActiveRecord::Migration
       t.string :name
       t.string :keywords
       t.text :description
-      t.references :creator, index: true, foreign_key: true
+      t.references :creator, index: true
 
       t.timestamps null: false
     end


### PR DESCRIPTION
PG is trying to index the 'creators' table, which doesn't exist because it should be 'users'
